### PR TITLE
[c-sharp] fix Semgrep pattern parsing for top-level expressions, declarations, and ellipsis positions

### DIFF
--- a/fyi/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/fyi/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -23,16 +23,35 @@ module.exports = grammar(standard_grammar, {
 
   conflicts: ($, previous) => [
     ...previous,
-    [$._expression, $.parameter]
+    [$._expression, $.parameter],
+    // Top-level property pattern (e.g. `public $T $P { get; init; }`)
+    // overlaps with `implicit_parameter` lookahead on `_type identifier`.
+    [$.implicit_parameter, $.property_declaration],
   ],
 
   rules: {
 
     // Entry point
+    //
+    // We add a bare top-level expression alternative so that Semgrep
+    // patterns like `$X is null`, `$X with { ... }`, `($X) => $E`,
+    // `$X?.$Y`, `typeof($T)`, `$X..$Y`, `$X[..$Y]`, `init $X => $Y`,
+    // `from $X in $Y select $E`, or `$\"hello {$X}\"` parse without
+    // requiring the `__SEMGREP_EXPRESSION` sentinel.
+    //
+    // We also add a bare `property_declaration` alternative so that
+    // `public $T $P { get; init; }` is not mis-parsed as a
+    // `local_declaration_statement` followed by a stray block.
+    //
+    // Both extra alternatives are given a strongly negative dynamic
+    // precedence so they only win when nothing else parses the input —
+    // a normal C# program still resolves through `previous`.
     compilation_unit: ($, previous) => {
       return choice(
         previous,
-        $.semgrep_expression
+        $.semgrep_expression,
+        prec.dynamic(-100, $._expression),
+        prec.dynamic(-100, $.property_declaration)
       );
     },
 
@@ -74,20 +93,20 @@ module.exports = grammar(standard_grammar, {
     },
 
     // We want ellipses to be interchangeable with namespace member declarations, so
-    // we need to add them in to `type_declaration` here. 
-    _type_declaration: ($, previous) => { 
+    // we need to add them in to `type_declaration` here.
+    _type_declaration: ($, previous) => {
       return choice(
         ...previous.members,
         $.ellipsis
       )
     },
 
-    // We do this because a file scoped namespace declaration is a top-level 
-    // thing, but ellipses are more particular. We want ellipses to be used 
+    // We do this because a file scoped namespace declaration is a top-level
+    // thing, but ellipses are more particular. We want ellipses to be used
     // in conjunction with file scoped namespace declarations.
-    // Unfortunately, in the base grammar, we can either have ellipsis 
-    // statements, or a file scoped declaration! That's no good. To play 
-    // around the previous grammar, we simply allow what came before to also 
+    // Unfortunately, in the base grammar, we can either have ellipsis
+    // statements, or a file scoped declaration! That's no good. To play
+    // around the previous grammar, we simply allow what came before to also
     // occur before a file scoped namespace declaration.
     file_scoped_namespace_declaration: ($, previous) => {
       return seq(
@@ -101,7 +120,30 @@ module.exports = grammar(standard_grammar, {
 	  $.ellipsis,
     ),
 
+    // Allow `...` as a switch-expression arm,
+    // e.g. `$X switch { $P => $E, ... }`.
+    switch_expression_arm: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
+    // Allow `<...>` in a generic type parameter list,
+    // e.g. `class $C<...> { }`.
+    type_parameter: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
     // Statement ellipsis: '...' not followed by ';'
+    //
+    // We also extend `expression_statement` to accept additional Semgrep
+    // expression-pattern shapes that the upstream
+    // `_expression_statement_expression` does not allow (it admits only
+    // assignment / invocation / unary / await / object-creation /
+    // parenthesized). Without these, patterns like `$X is $T $Y;`,
+    // `$"hello {$X}";`, `$X?.$Y;`, `typeof($T);`, `$X[..$Y];`,
+    // `$X..$Y;`, and `init $X => $Y;` would parse the expression at the
+    // top level but error on the trailing `;`.
     expression_statement: ($, previous) => {
       return choice(
         previous,
@@ -110,7 +152,16 @@ module.exports = grammar(standard_grammar, {
         seq($.deep_ellipsis, ';'),
         seq($.member_access_ellipsis_expression, ';'),
         seq($._semgrep_metavariable, ';'),
-        seq($.typed_metavariable, ';')
+        seq($.typed_metavariable, ';'),
+        // Semgrep-specific top-level expression shapes that upstream's
+        // `_expression_statement_expression` rejects.
+        seq($.is_pattern_expression, ';'),
+        seq($.interpolated_string_expression, ';'),
+        seq($.lambda_expression, ';'),
+        seq($.conditional_access_expression, ';'),
+        seq($.type_of_expression, ';'),
+        seq($.element_access_expression, ';'),
+        seq($.range_expression, ';'),
       );
     },
 

--- a/fyi/tree-sitter-version
+++ b/fyi/tree-sitter-version
@@ -1,1 +1,1 @@
-tree-sitter 0.22.6 (d521f0a0791d94f4442cf9be08322f6aabce20d6)
+tree-sitter 0.22.6 (fe20ef4a897aca50776903ada97bb1b04bbd7ef7)

--- a/fyi/versions
+++ b/fyi/versions
@@ -19,30 +19,45 @@ Last change in file:
       build: update bindings
 ---
 File: semgrep-grammars/src/semgrep-c-sharp/grammar.js
-Git repo name: ocaml-tree-sitter-semgrep
-Latest commit in repo: 091f5438fc0c15b80217f00e5b94ec0e55517383
+Git repo name: agent-ab9058662fbf6e2b6
+Latest commit in repo: 7b81197bc13613e0a71555f8fad4ff83bb0a27f4
 Last change in file:
-  commit dbb53feb5fe778e61d9feb6a899df3c2e346919f
-  Author: Martin Jambon <martin@r2c.dev>
-  Date:   Fri Sep 20 11:48:16 2024 -0700
+  commit 7b81197bc13613e0a71555f8fad4ff83bb0a27f4
+  Author: brandonspark <brandon@semgrep.com>
+  Date:   Wed Apr 29 17:39:49 2026 -0700
   
-      Add another git submodule for C# called c-sharp-pro (#512)
+      [c-sharp] fix Semgrep pattern parsing for top-level expressions, declarations, and ellipsis positions
       
-      * Add another submodule for C# (c-sharp-pro)
+      Extend `lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js` so several
+      modern C# pattern shapes that previously errored at parse time are now
+      admitted by the grammar:
       
-      * Mark c-sharp and c-sharp-pro as fully compatible with tree-sitter 0.22.6
+      - Top-level bare expression alternative on `compilation_unit`: covers
+        patterns without a trailing `;` like `$X is null`, `$X with { ... }`,
+        `$X is { $P: $V }`, `from $X in $Y where $C select $E`.
+      - Top-level bare `property_declaration` alternative: covers patterns
+        like `public $T $P { get; init; }` that were mis-parsed as a
+        `local_declaration_statement` followed by a stray block.
+      - `expression_statement` extended with the C# 7/8/9+ expression shapes
+        that upstream's `_expression_statement_expression` rejects, so
+        `$X is $T $Y;`, `$"hello {$X}";`, `($X) => $E;`, `$X?.$Y;`,
+        `typeof($T);`, `$X[..$Y];`, `$X..$Y;`, and `init $X => $Y;` all parse.
+      - `switch_expression_arm` accepts `$.ellipsis` so
+        `$X switch { $P => $E, ... }` parses.
+      - `type_parameter` accepts `$.ellipsis` so `class $C<...> { }` parses.
       
-      * Add new language 'c-sharp-pro' that tracks another version of
-      tree-sitter-c-sharp than the existing 'c-sharp'. C functions were renamed
-      so as to avoid conflicts when both parsers are used in the same program.
+      The new top-level alternatives are gated with strongly negative
+      `prec.dynamic` so that ordinary C# code still resolves through the
+      existing `previous` (i.e. `global_statement` /
+      `_namespace_member_declaration`) path. Targeted `conflicts` entries
+      disambiguate where the new alternatives unavoidably overlap with the
+      upstream rules.
       
-      * Fix release script to work on a blank destination repo
+      Closes LANG-478, LANG-484. Partially addresses LANG-494 (the augmentation
+      parts: switch-arm `...` and `<...>` type-parameter ellipsis). The
+      `I$I` metavariable+identifier concatenation case from LANG-494 is
+      deferred — it requires scanner-level work (token immediacy /
+      `token.immediate`) and is labeled `fix:scanner-or-entrypoint` upstream.
       
-      * Fix generated package name for c-sharp-pro
-      
-      * Add c-sharp-pro to the CircleCI tests
-      
-      * Move test file to where it should be
-      
-      * Fix comments in the semgrep grammar extensions for c-sharp and c-sharp-pro
+      Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 ---

--- a/lib/Boilerplate.ml
+++ b/lib/Boilerplate.ml
@@ -1451,6 +1451,21 @@ and map_checked_expression (env : env) (x : CST.checked_expression) =
     )
   )
 
+and map_conditional_access_expression (env : env) ((v1, v2, v3) : CST.conditional_access_expression) =
+  let v1 = map_expression env v1 in
+  let v2 = (* "?" *) token env v2 in
+  let v3 =
+    (match v3 with
+    | `Member_bind_exp x -> R.Case ("Member_bind_exp",
+        map_member_binding_expression env x
+      )
+    | `Elem_bind_exp x -> R.Case ("Elem_bind_exp",
+        map_element_binding_expression env x
+      )
+    )
+  in
+  R.Tuple [v1; v2; v3]
+
 and map_constant_pattern (env : env) (x : CST.constant_pattern) =
   (match x with
   | `Bin_exp x -> R.Case ("Bin_exp",
@@ -1522,6 +1537,11 @@ and map_default_expression (env : env) ((v1, v2) : CST.default_expression) =
   in
   R.Tuple [v1; v2]
 
+and map_element_access_expression (env : env) ((v1, v2) : CST.element_access_expression) =
+  let v1 = map_expression env v1 in
+  let v2 = map_element_binding_expression env v2 in
+  R.Tuple [v1; v2]
+
 and map_element_binding_expression (env : env) (x : CST.element_binding_expression) =
   map_bracketed_argument_list env x
 
@@ -1589,6 +1609,41 @@ and map_expression_statement (env : env) (x : CST.expression_statement) =
     )
   | `Typed_meta_SEMI (v1, v2) -> R.Case ("Typed_meta_SEMI",
       let v1 = map_typed_metavariable env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Is_pat_exp_SEMI (v1, v2) -> R.Case ("Is_pat_exp_SEMI",
+      let v1 = map_is_pattern_expression env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Inte_str_exp_SEMI (v1, v2) -> R.Case ("Inte_str_exp_SEMI",
+      let v1 = map_interpolated_string_expression env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Lambda_exp_SEMI (v1, v2) -> R.Case ("Lambda_exp_SEMI",
+      let v1 = map_lambda_expression env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Cond_access_exp_SEMI (v1, v2) -> R.Case ("Cond_access_exp_SEMI",
+      let v1 = map_conditional_access_expression env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Type_of_exp_SEMI (v1, v2) -> R.Case ("Type_of_exp_SEMI",
+      let v1 = map_type_of_expression env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Elem_access_exp_SEMI (v1, v2) -> R.Case ("Elem_access_exp_SEMI",
+      let v1 = map_element_access_expression env v1 in
+      let v2 = (* ";" *) token env v2 in
+      R.Tuple [v1; v2]
+    )
+  | `Range_exp_SEMI (v1, v2) -> R.Case ("Range_exp_SEMI",
+      let v1 = map_range_expression env v1 in
       let v2 = (* ";" *) token env v2 in
       R.Tuple [v1; v2]
     )
@@ -1835,6 +1890,51 @@ and map_invocation_expression (env : env) ((v1, v2) : CST.invocation_expression)
   let v2 = map_argument_list env v2 in
   R.Tuple [v1; v2]
 
+and map_is_pattern_expression (env : env) ((v1, v2, v3) : CST.is_pattern_expression) =
+  let v1 = map_expression env v1 in
+  let v2 = (* "is" *) token env v2 in
+  let v3 = map_pattern env v3 in
+  R.Tuple [v1; v2; v3]
+
+and map_lambda_expression (env : env) ((v1, v2, v3, v4, v5, v6) : CST.lambda_expression) =
+  let v1 = R.List (List.map (map_attribute_list env) v1) in
+  let v2 =
+    (match v2 with
+    | Some x -> R.Option (Some (
+        map_anon_choice_async_25087f5 env x
+      ))
+    | None -> R.Option None)
+  in
+  let v3 =
+    (match v3 with
+    | Some x -> R.Option (Some (
+        map_type_pattern env x
+      ))
+    | None -> R.Option None)
+  in
+  let v4 =
+    (match v4 with
+    | `Param_list x -> R.Case ("Param_list",
+        map_parameter_list env x
+      )
+    | `Impl_param_list x -> R.Case ("Impl_param_list",
+        map_implicit_parameter_list env x
+      )
+    )
+  in
+  let v5 = (* "=>" *) token env v5 in
+  let v6 =
+    (match v6 with
+    | `Blk x -> R.Case ("Blk",
+        map_block env x
+      )
+    | `Exp x -> R.Case ("Exp",
+        map_expression env x
+      )
+    )
+  in
+  R.Tuple [v1; v2; v3; v4; v5; v6]
+
 and map_lvalue_expression (env : env) (x : CST.lvalue_expression) =
   (match x with
   | `This_exp tok -> R.Case ("This_exp",
@@ -1849,10 +1949,8 @@ and map_lvalue_expression (env : env) (x : CST.lvalue_expression) =
   | `Simple_name x -> R.Case ("Simple_name",
       map_simple_name env x
     )
-  | `Elem_access_exp (v1, v2) -> R.Case ("Elem_access_exp",
-      let v1 = map_expression env v1 in
-      let v2 = map_element_binding_expression env v2 in
-      R.Tuple [v1; v2]
+  | `Elem_access_exp x -> R.Case ("Elem_access_exp",
+      map_element_access_expression env x
     )
   | `Elem_bind_exp x -> R.Case ("Elem_bind_exp",
       map_element_binding_expression env x
@@ -1985,20 +2083,8 @@ and map_non_lvalue_expression (env : env) (x : CST.non_lvalue_expression) =
   | `Chec_exp x -> R.Case ("Chec_exp",
       map_checked_expression env x
     )
-  | `Cond_access_exp (v1, v2, v3) -> R.Case ("Cond_access_exp",
-      let v1 = map_expression env v1 in
-      let v2 = (* "?" *) token env v2 in
-      let v3 =
-        (match v3 with
-        | `Member_bind_exp x -> R.Case ("Member_bind_exp",
-            map_member_binding_expression env x
-          )
-        | `Elem_bind_exp x -> R.Case ("Elem_bind_exp",
-            map_element_binding_expression env x
-          )
-        )
-      in
-      R.Tuple [v1; v2; v3]
+  | `Cond_access_exp x -> R.Case ("Cond_access_exp",
+      map_conditional_access_expression env x
     )
   | `Cond_exp (v1, v2, v3, v4, v5) -> R.Case ("Cond_exp",
       let v1 = map_expression env v1 in
@@ -2050,50 +2136,11 @@ and map_non_lvalue_expression (env : env) (x : CST.non_lvalue_expression) =
       let v3 = map_type_pattern env v3 in
       R.Tuple [v1; v2; v3]
     )
-  | `Is_pat_exp (v1, v2, v3) -> R.Case ("Is_pat_exp",
-      let v1 = map_expression env v1 in
-      let v2 = (* "is" *) token env v2 in
-      let v3 = map_pattern env v3 in
-      R.Tuple [v1; v2; v3]
+  | `Is_pat_exp x -> R.Case ("Is_pat_exp",
+      map_is_pattern_expression env x
     )
-  | `Lambda_exp (v1, v2, v3, v4, v5, v6) -> R.Case ("Lambda_exp",
-      let v1 = R.List (List.map (map_attribute_list env) v1) in
-      let v2 =
-        (match v2 with
-        | Some x -> R.Option (Some (
-            map_anon_choice_async_25087f5 env x
-          ))
-        | None -> R.Option None)
-      in
-      let v3 =
-        (match v3 with
-        | Some x -> R.Option (Some (
-            map_type_pattern env x
-          ))
-        | None -> R.Option None)
-      in
-      let v4 =
-        (match v4 with
-        | `Param_list x -> R.Case ("Param_list",
-            map_parameter_list env x
-          )
-        | `Impl_param_list x -> R.Case ("Impl_param_list",
-            map_implicit_parameter_list env x
-          )
-        )
-      in
-      let v5 = (* "=>" *) token env v5 in
-      let v6 =
-        (match v6 with
-        | `Blk x -> R.Case ("Blk",
-            map_block env x
-          )
-        | `Exp x -> R.Case ("Exp",
-            map_expression env x
-          )
-        )
-      in
-      R.Tuple [v1; v2; v3; v4; v5; v6]
+  | `Lambda_exp x -> R.Case ("Lambda_exp",
+      map_lambda_expression env x
     )
   | `Make_ref_exp (v1, v2, v3, v4) -> R.Case ("Make_ref_exp",
       let v1 = (* "__makeref" *) token env v1 in
@@ -2107,23 +2154,8 @@ and map_non_lvalue_expression (env : env) (x : CST.non_lvalue_expression) =
       let v2 = map_query_body env v2 in
       R.Tuple [v1; v2]
     )
-  | `Range_exp (v1, v2, v3) -> R.Case ("Range_exp",
-      let v1 =
-        (match v1 with
-        | Some x -> R.Option (Some (
-            map_expression env x
-          ))
-        | None -> R.Option None)
-      in
-      let v2 = (* ".." *) token env v2 in
-      let v3 =
-        (match v3 with
-        | Some x -> R.Option (Some (
-            map_expression env x
-          ))
-        | None -> R.Option None)
-      in
-      R.Tuple [v1; v2; v3]
+  | `Range_exp x -> R.Case ("Range_exp",
+      map_range_expression env x
     )
   | `Ref_exp (v1, v2) -> R.Case ("Ref_exp",
       let v1 = (* "ref" *) token env v1 in
@@ -2673,6 +2705,24 @@ and map_query_continuation (env : env) (x : CST.query_continuation) =
     )
   )
 
+and map_range_expression (env : env) ((v1, v2, v3) : CST.range_expression) =
+  let v1 =
+    (match v1 with
+    | Some x -> R.Option (Some (
+        map_expression env x
+      ))
+    | None -> R.Option None)
+  in
+  let v2 = (* ".." *) token env v2 in
+  let v3 =
+    (match v3 with
+    | Some x -> R.Option (Some (
+        map_expression env x
+      ))
+    | None -> R.Option None)
+  in
+  R.Tuple [v1; v2; v3]
+
 and map_ref_base_type (env : env) (x : CST.ref_base_type) =
   (match x with
   | `Impl_type tok -> R.Case ("Impl_type",
@@ -3130,18 +3180,25 @@ and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
   let v3 = (* "}" *) token env v3 in
   R.Tuple [v1; v2; v3]
 
-and map_switch_expression_arm (env : env) ((v1, v2, v3, v4) : CST.switch_expression_arm) =
-  let v1 = map_pattern env v1 in
-  let v2 =
-    (match v2 with
-    | Some x -> R.Option (Some (
-        map_when_clause env x
-      ))
-    | None -> R.Option None)
-  in
-  let v3 = (* "=>" *) token env v3 in
-  let v4 = map_expression env v4 in
-  R.Tuple [v1; v2; v3; v4]
+and map_switch_expression_arm (env : env) (x : CST.switch_expression_arm) =
+  (match x with
+  | `Pat_opt_when_clause_EQGT_exp (v1, v2, v3, v4) -> R.Case ("Pat_opt_when_clause_EQGT_exp",
+      let v1 = map_pattern env v1 in
+      let v2 =
+        (match v2 with
+        | Some x -> R.Option (Some (
+            map_when_clause env x
+          ))
+        | None -> R.Option None)
+      in
+      let v3 = (* "=>" *) token env v3 in
+      let v4 = map_expression env v4 in
+      R.Tuple [v1; v2; v3; v4]
+    )
+  | `Ellips tok -> R.Case ("Ellips",
+      (* "..." *) token env tok
+    )
+  )
 
 and map_switch_section (env : env) ((v1, v2) : CST.switch_section) =
   let v1 =
@@ -3275,24 +3332,31 @@ and map_type_of_expression (env : env) ((v1, v2, v3, v4) : CST.type_of_expressio
   let v4 = (* ")" *) token env v4 in
   R.Tuple [v1; v2; v3; v4]
 
-and map_type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
-  let v1 = R.List (List.map (map_attribute_list env) v1) in
-  let v2 =
-    (match v2 with
-    | Some x -> R.Option (Some (
-        (match x with
-        | `In tok -> R.Case ("In",
-            (* "in" *) token env tok
-          )
-        | `Out tok -> R.Case ("Out",
-            (* "out" *) token env tok
-          )
-        )
-      ))
-    | None -> R.Option None)
-  in
-  let v3 = map_implicit_parameter_list env v3 in
-  R.Tuple [v1; v2; v3]
+and map_type_parameter (env : env) (x : CST.type_parameter) =
+  (match x with
+  | `Rep_attr_list_opt_choice_in_id (v1, v2, v3) -> R.Case ("Rep_attr_list_opt_choice_in_id",
+      let v1 = R.List (List.map (map_attribute_list env) v1) in
+      let v2 =
+        (match v2 with
+        | Some x -> R.Option (Some (
+            (match x with
+            | `In tok -> R.Case ("In",
+                (* "in" *) token env tok
+              )
+            | `Out tok -> R.Case ("Out",
+                (* "out" *) token env tok
+              )
+            )
+          ))
+        | None -> R.Option None)
+      in
+      let v3 = map_implicit_parameter_list env v3 in
+      R.Tuple [v1; v2; v3]
+    )
+  | `Ellips tok -> R.Case ("Ellips",
+      (* "..." *) token env tok
+    )
+  )
 
 and map_type_parameter_constraint (env : env) (x : CST.type_parameter_constraint) =
   (match x with
@@ -3650,6 +3714,43 @@ let map_enum_member_declaration_list (env : env) ((v1, v2, v3, v4) : CST.enum_me
   let v4 = (* "}" *) token env v4 in
   R.Tuple [v1; v2; v3; v4]
 
+let map_property_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.property_declaration) =
+  let v1 = R.List (List.map (map_attribute_list env) v1) in
+  let v2 = R.List (List.map (map_modifier env) v2) in
+  let v3 = map_type_pattern env v3 in
+  let v4 =
+    (match v4 with
+    | Some x -> R.Option (Some (
+        map_explicit_interface_specifier env x
+      ))
+    | None -> R.Option None)
+  in
+  let v5 = map_implicit_parameter_list env v5 in
+  let v6 =
+    (match v6 with
+    | `Acce_list_opt_EQ_exp_SEMI (v1, v2) -> R.Case ("Acce_list_opt_EQ_exp_SEMI",
+        let v1 = map_accessor_list env v1 in
+        let v2 =
+          (match v2 with
+          | Some (v1, v2, v3) -> R.Option (Some (
+              let v1 = (* "=" *) token env v1 in
+              let v2 = map_expression env v2 in
+              let v3 = (* ";" *) token env v3 in
+              R.Tuple [v1; v2; v3]
+            ))
+          | None -> R.Option None)
+        in
+        R.Tuple [v1; v2]
+      )
+    | `Arrow_exp_clause_SEMI (v1, v2) -> R.Case ("Arrow_exp_clause_SEMI",
+        let v1 = map_arrow_expression_clause env v1 in
+        let v2 = (* ";" *) token env v2 in
+        R.Tuple [v1; v2]
+      )
+    )
+  in
+  R.Tuple [v1; v2; v3; v4; v5; v6]
+
 let map_enum_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.enum_declaration) =
   let v1 = R.List (List.map (map_attribute_list env) v1) in
   let v2 = R.List (List.map (map_modifier env) v2) in
@@ -3889,42 +3990,8 @@ and map_declaration (env : env) (x : CST.declaration) =
       let v9 = map_function_body env v9 in
       R.Tuple [v1; v2; v3; v4; v5; v6; v7; v8; v9]
     )
-  | `Prop_decl (v1, v2, v3, v4, v5, v6) -> R.Case ("Prop_decl",
-      let v1 = R.List (List.map (map_attribute_list env) v1) in
-      let v2 = R.List (List.map (map_modifier env) v2) in
-      let v3 = map_type_pattern env v3 in
-      let v4 =
-        (match v4 with
-        | Some x -> R.Option (Some (
-            map_explicit_interface_specifier env x
-          ))
-        | None -> R.Option None)
-      in
-      let v5 = map_implicit_parameter_list env v5 in
-      let v6 =
-        (match v6 with
-        | `Acce_list_opt_EQ_exp_SEMI (v1, v2) -> R.Case ("Acce_list_opt_EQ_exp_SEMI",
-            let v1 = map_accessor_list env v1 in
-            let v2 =
-              (match v2 with
-              | Some (v1, v2, v3) -> R.Option (Some (
-                  let v1 = (* "=" *) token env v1 in
-                  let v2 = map_expression env v2 in
-                  let v3 = (* ";" *) token env v3 in
-                  R.Tuple [v1; v2; v3]
-                ))
-              | None -> R.Option None)
-            in
-            R.Tuple [v1; v2]
-          )
-        | `Arrow_exp_clause_SEMI (v1, v2) -> R.Case ("Arrow_exp_clause_SEMI",
-            let v1 = map_arrow_expression_clause env v1 in
-            let v2 = (* ";" *) token env v2 in
-            R.Tuple [v1; v2]
-          )
-        )
-      in
-      R.Tuple [v1; v2; v3; v4; v5; v6]
+  | `Prop_decl x -> R.Case ("Prop_decl",
+      map_property_declaration env x
     )
   | `Record_decl x -> R.Case ("Record_decl",
       map_record_declaration env x
@@ -4182,6 +4249,12 @@ let map_compilation_unit (env : env) (x : CST.compilation_unit) =
       let v1 = (* "__SEMGREP_EXPRESSION" *) token env v1 in
       let v2 = map_expression env v2 in
       R.Tuple [v1; v2]
+    )
+  | `Exp x -> R.Case ("Exp",
+      map_expression env x
+    )
+  | `Prop_decl x -> R.Case ("Prop_decl",
+      map_property_declaration env x
     )
   )
 

--- a/lib/CST.ml
+++ b/lib/CST.ml
@@ -620,6 +620,15 @@ and checked_expression = [
     )
 ]
 
+and conditional_access_expression = (
+    expression
+  * Token.t (* "?" *)
+  * [
+        `Member_bind_exp of member_binding_expression
+      | `Elem_bind_exp of element_binding_expression
+    ]
+)
+
 and constant_pattern = [
     `Bin_exp of binary_expression
   | `Defa_exp of default_expression
@@ -648,6 +657,8 @@ and default_expression = (
   * (Token.t (* "(" *) * type_pattern * Token.t (* ")" *)) option
 )
 
+and element_access_expression = (expression * element_binding_expression)
+
 and element_binding_expression = bracketed_argument_list
 
 and equals_value_clause = (Token.t (* "=" *) * expression)
@@ -675,6 +686,17 @@ and expression_statement = [
     )
   | `Semg_meta_SEMI of (semgrep_metavariable (*tok*) * Token.t (* ";" *))
   | `Typed_meta_SEMI of (typed_metavariable * Token.t (* ";" *))
+  | `Is_pat_exp_SEMI of (is_pattern_expression * Token.t (* ";" *))
+  | `Inte_str_exp_SEMI of (
+        interpolated_string_expression * Token.t (* ";" *)
+    )
+  | `Lambda_exp_SEMI of (lambda_expression * Token.t (* ";" *))
+  | `Cond_access_exp_SEMI of (
+        conditional_access_expression * Token.t (* ";" *)
+    )
+  | `Type_of_exp_SEMI of (type_of_expression * Token.t (* ";" *))
+  | `Elem_access_exp_SEMI of (element_access_expression * Token.t (* ";" *))
+  | `Range_exp_SEMI of (range_expression * Token.t (* ";" *))
 ]
 
 and expression_statement_expression = [
@@ -789,12 +811,26 @@ and interpolation_alignment_clause = (Token.t (* "," *) * expression)
 
 and invocation_expression = (expression * argument_list)
 
+and is_pattern_expression = (expression * Token.t (* "is" *) * pattern)
+
+and lambda_expression = (
+    attribute_list list (* zero or more *)
+  * anon_choice_async_25087f5 option
+  * type_pattern option
+  * [
+        `Param_list of parameter_list
+      | `Impl_param_list of implicit_parameter_list
+    ]
+  * Token.t (* "=>" *)
+  * [ `Blk of block | `Exp of expression ]
+)
+
 and lvalue_expression = [
     `This_exp of Token.t (* "this" *)
   | `Member_access_exp of member_access_expression
   | `Tuple_exp of tuple_expression
   | `Simple_name of simple_name
-  | `Elem_access_exp of (expression * element_binding_expression)
+  | `Elem_access_exp of element_access_expression
   | `Elem_bind_exp of element_binding_expression
   | `Poin_indi_exp of (Token.t (* "*" *) * expression)
   | `Paren_lvalue_exp of (
@@ -849,14 +885,7 @@ and non_lvalue_expression = [
   | `Bin_exp of binary_expression
   | `Cast_exp of cast_expression
   | `Chec_exp of checked_expression
-  | `Cond_access_exp of (
-        expression
-      * Token.t (* "?" *)
-      * [
-            `Member_bind_exp of member_binding_expression
-          | `Elem_bind_exp of element_binding_expression
-        ]
-    )
+  | `Cond_access_exp of conditional_access_expression
   | `Cond_exp of (
         expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
       * expression
@@ -881,28 +910,14 @@ and non_lvalue_expression = [
   | `Init_exp of initializer_expression
   | `Inte_str_exp of interpolated_string_expression
   | `Is_exp of (expression * Token.t (* "is" *) * type_pattern)
-  | `Is_pat_exp of (expression * Token.t (* "is" *) * pattern)
-  | `Lambda_exp of (
-        attribute_list list (* zero or more *)
-      * anon_choice_async_25087f5 option
-      * type_pattern option
-      * [
-            `Param_list of parameter_list
-          | `Impl_param_list of implicit_parameter_list
-        ]
-      * Token.t (* "=>" *)
-      * [ `Blk of block | `Exp of expression ]
-    )
+  | `Is_pat_exp of is_pattern_expression
+  | `Lambda_exp of lambda_expression
   | `Make_ref_exp of (
         Token.t (* "__makeref" *) * Token.t (* "(" *) * expression
       * Token.t (* ")" *)
     )
   | `Query_exp of (from_clause * query_body)
-  | `Range_exp of (
-        expression option
-      * Token.t (* ".." *)
-      * expression option
-    )
+  | `Range_exp of range_expression
   | `Ref_exp of (Token.t (* "ref" *) * expression)
   | `Ref_type_exp of (
         Token.t (* "__reftype" *) * Token.t (* "(" *) * expression
@@ -1116,6 +1131,12 @@ and query_continuation = [
   `Rectype of (Token.t (* "into" *) * implicit_parameter_list * query_body)
 ]
 
+and range_expression = (
+    expression option
+  * Token.t (* ".." *)
+  * expression option
+)
+
 and ref_base_type = [
     `Impl_type of Token.t (* "var" *)
   | `Array_type of array_type
@@ -1312,12 +1333,15 @@ and switch_body = (
   * Token.t (* "}" *)
 )
 
-and switch_expression_arm = (
-    pattern
-  * when_clause option
-  * Token.t (* "=>" *)
-  * expression
-)
+and switch_expression_arm = [
+    `Pat_opt_when_clause_EQGT_exp of (
+        pattern
+      * when_clause option
+      * Token.t (* "=>" *)
+      * expression
+    )
+  | `Ellips of Token.t (* "..." *)
+]
 
 and switch_section = (
     [
@@ -1383,11 +1407,14 @@ and type_of_expression = (
   * Token.t (* ")" *)
 )
 
-and type_parameter = (
-    attribute_list list (* zero or more *)
-  * [ `In of Token.t (* "in" *) | `Out of Token.t (* "out" *) ] option
-  * implicit_parameter_list
-)
+and type_parameter = [
+    `Rep_attr_list_opt_choice_in_id of (
+        attribute_list list (* zero or more *)
+      * [ `In of Token.t (* "in" *) | `Out of Token.t (* "out" *) ] option
+      * implicit_parameter_list
+    )
+  | `Ellips of Token.t (* "..." *)
+]
 
 and type_parameter_constraint = [
     `Class_opt_QMARK of (Token.t (* "class" *) * Token.t (* "?" *) option)
@@ -1550,6 +1577,23 @@ type enum_member_declaration_list = (
   * Token.t (* "}" *)
 )
 
+type property_declaration = (
+    attribute_list list (* zero or more *)
+  * modifier list (* zero or more *)
+  * type_pattern
+  * explicit_interface_specifier option
+  * implicit_parameter_list
+  * [
+        `Acce_list_opt_EQ_exp_SEMI of (
+            accessor_list
+          * (Token.t (* "=" *) * expression * Token.t (* ";" *)) option
+        )
+      | `Arrow_exp_clause_SEMI of (
+            arrow_expression_clause * Token.t (* ";" *)
+        )
+    ]
+)
+
 type enum_declaration = (
     attribute_list list (* zero or more *)
   * modifier list (* zero or more *)
@@ -1666,22 +1710,7 @@ and declaration = [
       * parameter_list
       * function_body
     )
-  | `Prop_decl of (
-        attribute_list list (* zero or more *)
-      * modifier list (* zero or more *)
-      * type_pattern
-      * explicit_interface_specifier option
-      * implicit_parameter_list
-      * [
-            `Acce_list_opt_EQ_exp_SEMI of (
-                accessor_list
-              * (Token.t (* "=" *) * expression * Token.t (* ";" *)) option
-            )
-          | `Arrow_exp_clause_SEMI of (
-                arrow_expression_clause * Token.t (* ";" *)
-            )
-        ]
-    )
+  | `Prop_decl of property_declaration
   | `Record_decl of record_declaration
   | `Record_struct_decl of record_struct_declaration
   | `Struct_decl of struct_declaration
@@ -1799,6 +1828,8 @@ type compilation_unit = [
         ]
     )
   | `Semg_exp of (Token.t (* "__SEMGREP_EXPRESSION" *) * expression)
+  | `Exp of expression
+  | `Prop_decl of property_declaration
 ]
 
 type continue_statement (* inlined *) = (
@@ -1955,15 +1986,6 @@ type checked_statement (* inlined *) = (
   * block
 )
 
-type conditional_access_expression (* inlined *) = (
-    expression
-  * Token.t (* "?" *)
-  * [
-        `Member_bind_exp of member_binding_expression
-      | `Elem_bind_exp of element_binding_expression
-    ]
-)
-
 type conditional_expression (* inlined *) = (
     expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
   * expression
@@ -1976,10 +1998,6 @@ type declaration_pattern (* inlined *) = (
 type do_statement (* inlined *) = (
     Token.t (* "do" *) * global_statement * Token.t (* "while" *)
   * Token.t (* "(" *) * expression * Token.t (* ")" *) * Token.t (* ";" *)
-)
-
-type element_access_expression (* inlined *) = (
-    expression * element_binding_expression
 )
 
 type fixed_statement (* inlined *) = (
@@ -2068,10 +2086,6 @@ type is_expression (* inlined *) = (
     expression * Token.t (* "is" *) * type_pattern
 )
 
-type is_pattern_expression (* inlined *) = (
-    expression * Token.t (* "is" *) * pattern
-)
-
 type join_clause (* inlined *) = (
     Token.t (* "join" *)
   * type_pattern option
@@ -2087,18 +2101,6 @@ type join_clause (* inlined *) = (
 
 type labeled_statement (* inlined *) = (
     implicit_parameter_list * Token.t (* ":" *) * global_statement
-)
-
-type lambda_expression (* inlined *) = (
-    attribute_list list (* zero or more *)
-  * anon_choice_async_25087f5 option
-  * type_pattern option
-  * [
-        `Param_list of parameter_list
-      | `Impl_param_list of implicit_parameter_list
-    ]
-  * Token.t (* "=>" *)
-  * [ `Blk of block | `Exp of expression ]
 )
 
 type let_clause (* inlined *) = (
@@ -2187,12 +2189,6 @@ type qualified_name (* inlined *) = (
 )
 
 type query_expression (* inlined *) = (from_clause * query_body)
-
-type range_expression (* inlined *) = (
-    expression option
-  * Token.t (* ".." *)
-  * expression option
-)
 
 type recursive_pattern (* inlined *) = (
     type_pattern option
@@ -2388,23 +2384,6 @@ type indexer_declaration (* inlined *) = (
   * bracketed_parameter_list
   * [
         `Acce_list of accessor_list
-      | `Arrow_exp_clause_SEMI of (
-            arrow_expression_clause * Token.t (* ";" *)
-        )
-    ]
-)
-
-type property_declaration (* inlined *) = (
-    attribute_list list (* zero or more *)
-  * modifier list (* zero or more *)
-  * type_pattern
-  * explicit_interface_specifier option
-  * implicit_parameter_list
-  * [
-        `Acce_list_opt_EQ_exp_SEMI of (
-            accessor_list
-          * (Token.t (* "=" *) * expression * Token.t (* ";" *)) option
-        )
       | `Arrow_exp_clause_SEMI of (
             arrow_expression_clause * Token.t (* ";" *)
         )

--- a/lib/Parse.ml
+++ b/lib/Parse.ml
@@ -1297,6 +1297,34 @@ let children_regexps : (string * Run.exp option) list = [
         Token (Name "typed_metavariable");
         Token (Literal ";");
       ];
+      Seq [
+        Token (Name "is_pattern_expression");
+        Token (Literal ";");
+      ];
+      Seq [
+        Token (Name "interpolated_string_expression");
+        Token (Literal ";");
+      ];
+      Seq [
+        Token (Name "lambda_expression");
+        Token (Literal ";");
+      ];
+      Seq [
+        Token (Name "conditional_access_expression");
+        Token (Literal ";");
+      ];
+      Seq [
+        Token (Name "type_of_expression");
+        Token (Literal ";");
+      ];
+      Seq [
+        Token (Name "element_access_expression");
+        Token (Literal ";");
+      ];
+      Seq [
+        Token (Name "range_expression");
+        Token (Literal ";");
+      ];
     |];
   );
   "expression_statement_expression",
@@ -2511,14 +2539,17 @@ let children_regexps : (string * Run.exp option) list = [
   );
   "switch_expression_arm",
   Some (
-    Seq [
-      Token (Name "pattern");
-      Opt (
-        Token (Name "when_clause");
-      );
-      Token (Literal "=>");
-      Token (Name "expression");
-    ];
+    Alt [|
+      Seq [
+        Token (Name "pattern");
+        Opt (
+          Token (Name "when_clause");
+        );
+        Token (Literal "=>");
+        Token (Name "expression");
+      ];
+      Token (Name "ellipsis");
+    |];
   );
   "switch_section",
   Some (
@@ -2670,18 +2701,21 @@ let children_regexps : (string * Run.exp option) list = [
   );
   "type_parameter",
   Some (
-    Seq [
-      Repeat (
-        Token (Name "attribute_list");
-      );
-      Opt (
-        Alt [|
-          Token (Literal "in");
-          Token (Literal "out");
-        |];
-      );
-      Token (Name "identifier");
-    ];
+    Alt [|
+      Seq [
+        Repeat (
+          Token (Name "attribute_list");
+        );
+        Opt (
+          Alt [|
+            Token (Literal "in");
+            Token (Literal "out");
+          |];
+        );
+        Token (Name "identifier");
+      ];
+      Token (Name "ellipsis");
+    |];
   );
   "type_parameter_constraint",
   Some (
@@ -3548,6 +3582,8 @@ let children_regexps : (string * Run.exp option) list = [
         |];
       ];
       Token (Name "semgrep_expression");
+      Token (Name "expression");
+      Token (Name "property_declaration");
     |];
   );
 ]
@@ -6551,6 +6587,83 @@ and trans_expression_statement ((kind, body) : mt) : CST.expression_statement =
             | _ -> assert false
             )
           )
+      | Alt (7, v) ->
+          `Is_pat_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_is_pattern_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (8, v) ->
+          `Inte_str_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_interpolated_string_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (9, v) ->
+          `Lambda_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_lambda_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (10, v) ->
+          `Cond_access_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_conditional_access_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (11, v) ->
+          `Type_of_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_type_of_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (12, v) ->
+          `Elem_access_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_element_access_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (13, v) ->
+          `Range_exp_SEMI (
+            (match v with
+            | Seq [v0; v1] ->
+                (
+                  trans_range_expression (Run.matcher_token v0),
+                  Run.trans_token (Run.matcher_token v1)
+                )
+            | _ -> assert false
+            )
+          )
       | _ -> assert false
       )
   | Leaf _ -> assert false
@@ -9177,15 +9290,25 @@ and trans_switch_expression_arm ((kind, body) : mt) : CST.switch_expression_arm 
   match body with
   | Children v ->
       (match v with
-      | Seq [v0; v1; v2; v3] ->
-          (
-            trans_pattern (Run.matcher_token v0),
-            Run.opt
-              (fun v -> trans_when_clause (Run.matcher_token v))
-              v1
-            ,
-            Run.trans_token (Run.matcher_token v2),
-            trans_expression (Run.matcher_token v3)
+      | Alt (0, v) ->
+          `Pat_opt_when_clause_EQGT_exp (
+            (match v with
+            | Seq [v0; v1; v2; v3] ->
+                (
+                  trans_pattern (Run.matcher_token v0),
+                  Run.opt
+                    (fun v -> trans_when_clause (Run.matcher_token v))
+                    v1
+                  ,
+                  Run.trans_token (Run.matcher_token v2),
+                  trans_expression (Run.matcher_token v3)
+                )
+            | _ -> assert false
+            )
+          )
+      | Alt (1, v) ->
+          `Ellips (
+            trans_ellipsis (Run.matcher_token v)
           )
       | _ -> assert false
       )
@@ -9505,29 +9628,39 @@ and trans_type_parameter ((kind, body) : mt) : CST.type_parameter =
   match body with
   | Children v ->
       (match v with
-      | Seq [v0; v1; v2] ->
-          (
-            Run.repeat
-              (fun v -> trans_attribute_list (Run.matcher_token v))
-              v0
-            ,
-            Run.opt
-              (fun v ->
-                (match v with
-                | Alt (0, v) ->
-                    `In (
-                      Run.trans_token (Run.matcher_token v)
+      | Alt (0, v) ->
+          `Rep_attr_list_opt_choice_in_id (
+            (match v with
+            | Seq [v0; v1; v2] ->
+                (
+                  Run.repeat
+                    (fun v -> trans_attribute_list (Run.matcher_token v))
+                    v0
+                  ,
+                  Run.opt
+                    (fun v ->
+                      (match v with
+                      | Alt (0, v) ->
+                          `In (
+                            Run.trans_token (Run.matcher_token v)
+                          )
+                      | Alt (1, v) ->
+                          `Out (
+                            Run.trans_token (Run.matcher_token v)
+                          )
+                      | _ -> assert false
+                      )
                     )
-                | Alt (1, v) ->
-                    `Out (
-                      Run.trans_token (Run.matcher_token v)
-                    )
-                | _ -> assert false
+                    v1
+                  ,
+                  trans_identifier (Run.matcher_token v2)
                 )
-              )
-              v1
-            ,
-            trans_identifier (Run.matcher_token v2)
+            | _ -> assert false
+            )
+          )
+      | Alt (1, v) ->
+          `Ellips (
+            trans_ellipsis (Run.matcher_token v)
           )
       | _ -> assert false
       )
@@ -11191,6 +11324,14 @@ let trans_compilation_unit ((kind, body) : mt) : CST.compilation_unit =
       | Alt (1, v) ->
           `Semg_exp (
             trans_semgrep_expression (Run.matcher_token v)
+          )
+      | Alt (2, v) ->
+          `Exp (
+            trans_expression (Run.matcher_token v)
+          )
+      | Alt (3, v) ->
+          `Prop_decl (
+            trans_property_declaration (Run.matcher_token v)
           )
       | _ -> assert false
       )


### PR DESCRIPTION
## Summary

Generated parser updates from ocaml-tree-sitter-semgrep to fix several
modern C# pattern shapes that previously errored at parse time.

Companion PR with the grammar changes:
https://github.com/semgrep/ocaml-tree-sitter-semgrep/pull/584

### Tickets

- Closes LANG-478 (top-level expression patterns).
- Closes LANG-484 (top-level LINQ + property declarations).
- Partially addresses LANG-494 (augmentation parts only):
  switch-arm `...` and `<...>` type-parameter ellipsis are fixed here.
  The `I$I` metavariable+identifier concatenation case from LANG-494
  is deferred — it requires scanner-level work and is labeled
  `fix:scanner-or-entrypoint` upstream.

## Test plan

- [x] Generated by `./release --branch fix/c-sharp-pattern-augmentation c-sharp`
  from ocaml-tree-sitter-semgrep commit 7b81197.
- [x] All 188 corpus tests pass on the upstream grammar (15 new).
- [x] `tree-sitter parse` spot-checked on every pattern listed in the
  three Linear tickets.
- [ ] Wait for CI on the upstream PR and on this PR.